### PR TITLE
OptionT type parameters were required

### DIFF
--- a/src/main/tut/docs/stack/README.md
+++ b/src/main/tut/docs/stack/README.md
@@ -109,7 +109,7 @@ import cats.data.OptionT
 
 def getCustomer[F[_]](id: CustomerId)(implicit app: App[F]): FreeS[F, Option[Customer]] =
   // first try to get the customer from the cache
-  OptionT(app.cacheM.get(id).freeS).orElseF {
+  OptionT[FreeS[F, ?], Customer](app.cacheM.get(id).freeS).orElseF {
     // otherwise fallback and get the customer from a persistent store http://typelevel.org/cats/datatypes/optiont.html
     for {
       customer <- app.persistence.customer.getCustomer(id).freeS


### PR DESCRIPTION
Code was copied to https://github.com/simon-morgan/freestyle-trial/blob/master/src/main/scala/FreeExampleTargetStack.scala as part of a trial.  Compilation failed initially. Debug led to adding OptionT type parameters after which compile & run were successful.